### PR TITLE
Exclude inapp from rankings

### DIFF
--- a/tap_appfigures/runner.py
+++ b/tap_appfigures/runner.py
@@ -66,6 +66,7 @@ class AppFiguresRunner:
             if stream.STREAM_NAME == 'products':
                 self.sync_stream(stream)
                 product_ids = stream.product_ids
+                product_types = stream.product_types
 
         # Sync all but the products
         for stream in self.streams:
@@ -73,4 +74,5 @@ class AppFiguresRunner:
                 continue
 
             stream.product_ids = product_ids
+            stream.product_types = product_types
             self.sync_stream(stream)

--- a/tap_appfigures/streams/base.py
+++ b/tap_appfigures/streams/base.py
@@ -92,6 +92,7 @@ class AppFiguresBase:
         self.bookmark_date = str_to_date(bookmark_date)
 
         self.product_ids = []
+        self.product_types = []
 
     def sync(self):
         """

--- a/tap_appfigures/streams/products.py
+++ b/tap_appfigures/streams/products.py
@@ -23,11 +23,13 @@ class ProductsStream(AppFiguresBase):
 
         product_response = self.client.make_request("/products/mine")
         product_ids = []
+        product_types = []
         with singer.metrics.Counter('record_count', {'endpoint': 'products'}) as counter:
 
             for product in product_response.json().values():
                 record = ProductRecord(product, self.schema)
                 product_ids.append(record.clean_data['id'])
+                product_types.append(record.clean_data['type'])
 
                 # Only upsert messages which have changed
                 if record.product_date > self.bookmark_date:
@@ -42,3 +44,4 @@ class ProductsStream(AppFiguresBase):
         self.state = singer.write_bookmark(self.state, self.STREAM_NAME, 'last_record', date_to_str(max_product_date))
 
         self.product_ids = product_ids
+        self.product_types = product_types


### PR DESCRIPTION
Ran into an error when trying to pull rankings from in-app purchases.
This wasn't allowed so I decided to exclude the in-app purchases and fetch  the remaining products. 

I have only been able to test this on "inapp" and "app" products. There is another category: "book", which I haven't been able to test. 